### PR TITLE
Completely force deletion of everything in app namespace

### DIFF
--- a/lifecycle/lifecycle.sh
+++ b/lifecycle/lifecycle.sh
@@ -38,6 +38,8 @@ delete_original_app() {
         k3s kubectl delete all --all -n "$namespace" --grace-period=0 --force > /dev/null 2>&1
     fi
 
+    k3s kubectl get zv -o name -n openebs|xargs -i k3s kubectl patch {} -p '{"metadata":{"finalizers":[]}}' --type=merge -n openebs
+
     echo -e "\n${bold}Deleting the original app...${reset}"
     if ! output=$(cli -c "app chart_release delete release_name=\"${appname}\"" 2>&1); then
         echo -e "${red}Error: Failed to delete the app.${reset}"

--- a/lifecycle/lifecycle.sh
+++ b/lifecycle/lifecycle.sh
@@ -25,11 +25,17 @@ delete_original_app() {
     local dataset="${ix_apps_pool}/ix-applications/releases/${appname}"
 
     echo -e "${bold}Checking for pods in $namespace...${reset}"
-    local total_pods
-    total_pods=$(k3s kubectl get pods -n "$namespace" --no-headers)
+    local total_objects
+    total_objects=$(k3s kubectl get all -n "$namespace" --no-headers)
 
-    if [[ -n "$total_pods" ]]; then
-        k3s kubectl delete pods --all -n "$namespace" --grace-period=0 --force > /dev/null 2>&1
+    if [[ -n "$total_objects" ]]; then
+        k3s kubectl delete all --all -n "$namespace" --grace-period=10  > /dev/null 2>&1
+    fi
+
+    total_objects=$(k3s kubectl get all -n "$namespace" --no-headers)
+
+    if [[ -n "$total_objects" ]]; then
+        k3s kubectl delete all --all -n "$namespace" --grace-period=0 --force > /dev/null 2>&1
     fi
 
     echo -e "\n${bold}Deleting the original app...${reset}"


### PR DESCRIPTION
This PR forced complete deletion of every stock object in the App namespace.

It tries to do so cleanly, without the chance of remnant processes staying running (which might lead to datasetbussy errors for example).

However, if, after trying to do it cleanly, it still finds stuff, it forcefully nukes it still.

---

Once that is al done, it then goes ahead and ensures there are no "finalizers" on zfsvolumes objects in the old "openebs" namespace, these finalisers prevent deletion of said objects, which also keeps the datasets locked.